### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Since November 2018, Max Prokhorov (**@mcspr**) is also actively working as a co
 
 ## Contributors
 
-**Without your help this project would not be possible**. I (**@xoseperez**) simply can't spend all the time I wish on ESPurna but luckly I recieve a lot of contributions, bug fixes, enhancement suggestions,... from people all around the world. I would like to thank each and every one of you. The [contributors](https://github.com/xoseperez/espurna/graphs/contributors) page shows the ones that have done a PR in the past, but I also get contributions in the issues, by email or via the [gitter ESPurna channel](https://gitter.im/tinkerman-cat/espurna), those I also want to thank.
+**Without your help this project would not be possible**. I (**@xoseperez**) simply can't spend all the time I wish on ESPurna but luckily I receive a lot of contributions, bug fixes, enhancement suggestions,... from people all around the world. I would like to thank each and every one of you. The [contributors](https://github.com/xoseperez/espurna/graphs/contributors) page shows the ones that have done a PR in the past, but I also get contributions in the issues, by email or via the [gitter ESPurna channel](https://gitter.im/tinkerman-cat/espurna), those I also want to thank.
 
 **Thank you all very much**.
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -2,7 +2,7 @@
 
 If you're looking for support for ESPurna there are some options available:
 
-* [Issues](https://github.com/xoseperez/espurna/issues?utf8=%E2%9C%93&q=is%3Aissue): this is the most dinamic channel at the moment, you might find an answer to your question by searching current or closed issues.
+* [Issues](https://github.com/xoseperez/espurna/issues?utf8=%E2%9C%93&q=is%3Aissue): this is the most dynamic channel at the moment, you might find an answer to your question by searching current or closed issues.
 * [Wiki pages](https://github.com/xoseperez/espurna/wiki): might not be as up-to-date as we all would like (hey, you can also contribute in the documentation!).
 * [Gitter channel](https://gitter.im/tinkerman-cat/espurna): you have better chances to get fast answers from me or other ESPurna users.
 * [Issue a question](https://github.com/xoseperez/espurna/issues/new/choose): as a last resort, you can open new *question* issues on GitHub. Just remember: the more info you provide the more chances you'll have to get an accurate answer.

--- a/code/espurna/api.cpp
+++ b/code/espurna/api.cpp
@@ -357,7 +357,7 @@ bool is_json(AsyncWebServerRequest* request) {
 // - Server never checks for request closing in filter or canHandle, so if we don't want to handle large content-length, it
 //   will still flow through the lwip backend.
 // - `request->_tempObject` is used to keep API request state, but it's just a plain void pointer
-// - `request->send(..., payload)` creates a heap-allocated `reponse` object that will copy the payload and tracks it by a basic pointer.
+// - `request->send(..., payload)` creates a heap-allocated `response` object that will copy the payload and tracks it by a basic pointer.
 //   In case we call `request->send` a 2nd time (regardless of the type of the send()), it creates a 2nd object without de-allocating the 1st one.
 // - espasyncwebserver will `free(_tempObject)` when request is disconnected, but only after this callbackhandler is done.
 //   make sure it's set to nullptr via `AsyncWebServerRequest::onDisconnect`

--- a/code/espurna/api.h
+++ b/code/espurna/api.h
@@ -20,7 +20,7 @@ namespace espurna {
 namespace api {
 
 using BasicHandler = std::function<bool(Request&)>;
-using JsonHandler = std::function<bool(Request&, JsonObject& reponse)>;
+using JsonHandler = std::function<bool(Request&, JsonObject& response)>;
 
 } // namespace api
 } // namespace espurna

--- a/code/espurna/config/general.h
+++ b/code/espurna/config/general.h
@@ -1642,12 +1642,12 @@
 
 #ifndef IR_TX_REPEATS
 #define IR_TX_REPEATS               0               // (number) additional number of times that the message will be sent per series
-                                                    // (currently, only for simple payloads. *may* be overriden by the protocol or the option)
+                                                    // (currently, only for simple payloads. *may* be overridden by the protocol or the option)
 #endif
 
 #ifndef IR_TX_SERIES
 #define IR_TX_SERIES                1               // (number) default number of times that the message will be sent
-                                                    // (can be overriden in the MQTT payload option for the specific message)
+                                                    // (can be overridden in the MQTT payload option for the specific message)
 #endif
 
 #ifndef IR_TX_DELAY
@@ -1656,7 +1656,7 @@
 #endif
 
 #ifndef IR_RX_DELAY
-#define IR_RX_DELAY                 100             // (ms) minimum amount of time to wait before processing incomming message
+#define IR_RX_DELAY                 100             // (ms) minimum amount of time to wait before processing incoming message
 #endif
 
 #ifndef IR_RX_PRESET

--- a/code/espurna/config/hardware.h
+++ b/code/espurna/config/hardware.h
@@ -4005,7 +4005,7 @@
     #define I2C_SCL_PIN         14
 
 // -----------------------------------------------------------------------------
-// This device has teh same behaviour as the GOSUND WP3, but with different GPIO pin values
+// This device has the same behaviour as the GOSUND WP3, but with different GPIO pin values
 // GPIO equivalents extracted from https://templates.blakadder.com/aoycocr_X5P.html
 
 #elif defined(AOYCOCR_X5P)

--- a/code/espurna/config/types.h
+++ b/code/espurna/config/types.h
@@ -384,8 +384,8 @@
 
 #define MAGNITUDE_MAX               39
 
-// TODO: backwards compatible sensor integer values. should probably allow custom messsages
-// (even with the increased flash arequirements)
+// TODO: backwards compatible sensor integer values. should probably allow custom messages
+// (even with the increased flash requirements)
 
 #define SENSOR_ERROR_OK             0       // No error
 #define SENSOR_ERROR_OUT_OF_RANGE   1       // Result out of sensor range

--- a/code/espurna/crash.cpp
+++ b/code/espurna/crash.cpp
@@ -36,8 +36,8 @@ Copyright (C) 2019-2020 by Maxim Prokhorov <prokhorov dot max at outlook dot com
  *  6. epc3
  *  7. excvaddr
  *  8. depc
- *  9. adress of stack start
- * 10. adress of stack end
+ *  9. address of stack start
+ * 10. address of stack end
  * 11. stack trace size
  * 12. stack trace bytes
  *     ...

--- a/code/espurna/curtain_kingart.cpp
+++ b/code/espurna/curtain_kingart.cpp
@@ -262,7 +262,7 @@ void _KACurtainResult() {
             _KASetMoving();
             /*
                 (*1) ATTENTION THERE :
-                Send immediatly a AT+START - we need to purge the first response.
+                Send an AT+START immediately - we need to purge the first response.
                 It will return us the right direction of the switch but the position
                 we set instead of the real on. We take care of the switch response but
                 we ignore the position.

--- a/code/espurna/homeassistant.cpp
+++ b/code/espurna/homeassistant.cpp
@@ -359,7 +359,7 @@ String quote(String&& value) {
 // - In case the object uses the JSON makeObject() as state, make sure we don't use it (state)
 //   and the object itself after next() or ok() return false
 // - Make sure JSON state is not created on construction, but lazy-loaded as soon as it is needed.
-//   Meaning, we don't cause invalid refs immediatly when there are more than 1 discovery object present and we reset the storage.
+//   Meaning, we don't cause invalid refs immediately when there are more than 1 discovery object present and we reset the storage.
 
 class Discovery {
 public:

--- a/code/espurna/ir.cpp
+++ b/code/espurna/ir.cpp
@@ -456,7 +456,7 @@ unsigned long sized(StringView value) {
 //                (ref. IRremoteESP8266.h and it's protocol descriptions)
 //
 //   Optional payload parameters:
-//     REPEATS  - how many times the message will be sent immediatly
+//     REPEATS  - how many times the message will be sent immediately
 //                (defaults to 0 or the value set by the PROTOCOL type)
 //     SERIES   - how many times the message will be scheduled for sending
 //                (defaults to 1 aka once, [1...120))
@@ -469,11 +469,11 @@ unsigned long sized(StringView value) {
 // TODO: type is numeric based on the previous implementation. note that there are
 // `::typeToString(decode_type_t)` and `::strToDecodeType(const char*)` (IRutils.h)
 // And also see `const char kAllProtocolNames*`, which is a global from the IRtext header with
-// \0-terminated chunks of stringivied decode_type_t (counting 'index' will deduce the type)
+// \0-terminated chunks of stringified decode_type_t (counting 'index' will deduce the type)
 //
 // (but, notice that str->type only works with C strings and *will* do a permissive
 // `strToDecodeType(typeToString(static_cast<decode_type_t>(atoi(str))))` when the
-// intial attempt fails)
+// initial attempt fails)
 
 namespace simple {
 
@@ -1947,7 +1947,7 @@ private:
 //       (also, extending the current set of tests and / or having some helper macro that can fill the boilerplate)
 
 // As a (temporary?) solution for right now, have these 4 macros that setup a Context object and a list of test runners.
-// Each runner may call `IR_TEST(<something resolving to bool>)` to immediatly exit current block on failure and save report to the Context object.
+// Each runner may call `IR_TEST(<something resolving to bool>)` to immediately exit current block on failure and save report to the Context object.
 // On destruction of the Context object, every report is printed to the debug output.
 
 #define IR_TEST_SETUP_BEGIN() Context runner ## __FILE__ ## __LINE__ {

--- a/code/espurna/libs/WebSocketIncomingBuffer.h
+++ b/code/espurna/libs/WebSocketIncomingBuffer.h
@@ -1,6 +1,6 @@
 /*
 
-WebSocketIncommingBuffer
+WebSocketIncomingBuffer
 
 Code by Hermann Kraus (https://bitbucket.org/hermr2d2/)
 and slightly modified.

--- a/code/espurna/libs/fs_math.h
+++ b/code/espurna/libs/fs_math.h
@@ -54,8 +54,8 @@ long double fs_fmodl(long double x, long double y);
 > > compliant as I am running on a Z/OS mainframe.
 > >
 > > I would love to use the standard library but
-> > unfortunatly I'm using a
-> > stripped down version of C that looses the the runtime library
+> > unfortunately I'm using a
+> > stripped down version of C that loses the runtime library
 > > (we have to write our own).
 >
 > long double Ssqrt(long double x)

--- a/code/espurna/mdns.cpp
+++ b/code/espurna/mdns.cpp
@@ -118,7 +118,7 @@ void mdnsServerSetup() {
 //       which will completely reset the MDNS object and require a setup once again.
 //       this does not seem to work reliably :/ only support STA for the time being
 // 3.0.0 and newer only need to do MDNS.begin() once at setup()
-//       however, note that without begin() call it will immediatly crash b/c
+//       however, note that without begin() call it will immediately crash b/c
 //       there are no sanity checks if it was actually called
 #if defined(ARDUINO_ESP8266_RELEASE_2_7_2) \
     || defined(ARDUINO_ESP8266_RELEASE_2_7_3) \

--- a/code/espurna/nofuss.cpp
+++ b/code/espurna/nofuss.cpp
@@ -148,7 +148,7 @@ void nofussSetup() {
             // Disabling EEPROM rotation to prevent writing to EEPROM after the upgrade
             eepromRotate(false);
 
-            // Force backup right now, because NoFUSS library will immediatly reset on success
+            // Force backup right now, because NoFUSS library will immediately reset on success
             eepromBackup(0);
         }
 

--- a/code/espurna/scheduler_common.ipp
+++ b/code/espurna/scheduler_common.ipp
@@ -694,7 +694,7 @@ bool closest_offset_result(Search& search, const SearchValidate::Validate& valid
 
             reconstruct = true;
 
-        // daylight saving time shift occured, probe for duplicate hour
+        // daylight saving time shift occurred, probe for duplicate hour
         } else if (tmp.tm_isdst != search.result.tm_isdst) {
             tm test;
             test = tmp;

--- a/code/espurna/sensor.cpp
+++ b/code/espurna/sensor.cpp
@@ -4390,7 +4390,7 @@ void loop() {
             // Absolute value correction. *Unconditional*, value is always offset by this amount
             state.processed.value += magnitude.correction;
 
-            // In case units change occured, make sure filter receives the same unit type
+            // In case units change occurred, make sure filter receives the same unit type
             if (magnitude.last.units != state.processed.units) {
                 magnitude.filter->reset();
             }

--- a/code/espurna/sensors/PZEM004TSensor.h
+++ b/code/espurna/sensors/PZEM004TSensor.h
@@ -551,7 +551,7 @@ public:
             return;
         }
 
-        // Current approach is to spread our reads of mutliple instances,
+        // Current approach is to spread our reads of multiple instances,
         // instead of doing them in the same time slot.
         if (TimeSource::now() - _last_read < ReadInterval) {
             return;

--- a/code/espurna/settings_embedis.h
+++ b/code/espurna/settings_embedis.h
@@ -88,7 +88,7 @@ private:
     // XXX:  It does not matter right now, but we **will** overflow position when using sizes >= (2^16) - 1
     // Note: Implementation is also in the header b/c c++ won't allow us
     //       to have a plain member (not a ptr or ref) of unknown size.
-    // Note: There was a considiration to implement this as 'stashing iterator' to be compatible with stl algorithms.
+    // Note: There was a consideration to implement this as 'stashing iterator' to be compatible with stl algorithms.
     //       In such implementation, we would store intermediate index and allow the user to receive a `value_proxy`,
     //       temporary returned by `value_proxy& operator*()' that is bound to Cursor instance.
     //       This **will** cause problems with 'reverse_iterator' or anything like it, as it expects reference to

--- a/code/espurna/web.cpp
+++ b/code/espurna/web.cpp
@@ -186,7 +186,7 @@ bool RequestPrint::_addBuffer() {
 // This API expects a **very** careful approach to context switching between SYS and CONT:
 // - Returning RESPONSE_TRY_AGAIN before buffers are filled will result in invalid size marker being sent on the wire.
 //   HTTP client (curl, python requests etc., as discovered in testing) will then drop the connection
-// - Returning 0 will immediatly close the connection from our side
+// - Returning 0 will immediately close the connection from our side
 // - Calling _prepareRequest() **before** _buffers are filled will result in returning 0
 // - Calling yield() / delay() while request handler is active **may** trigger this callback out of sequence
 //   (e.g. Stream.write(...), Stream.read(...), DEBUG_MSG(...), or any other API trying to switch contexts)
@@ -679,7 +679,7 @@ void _onRequest(AsyncWebServerRequest *request){
     // No subscriber handled the request, return a 404 with implicit "Connection: close"
     request->send(404);
 
-    // And immediatly close the connection, ref: https://github.com/xoseperez/espurna/issues/1660
+    // And immediately close the connection, ref: https://github.com/xoseperez/espurna/issues/1660
     // Not doing so will cause memory exhaustion, because the connection will linger
     request->client()->close();
 

--- a/code/espurna/wifi.cpp
+++ b/code/espurna/wifi.cpp
@@ -1702,7 +1702,7 @@ bool scanning() {
 //
 // TODO: instead of bool, do a state object that is 'armed' before use and it is possible to make sure there's an expected value swap between `true` and `false`
 // (i.e. 'disarmed', 'armed-for', 'received-success', 'received-failure'. where 'armed-for' only reacts on a specific assignment, and the consumer
-// checks whether 'received-success' had happend, and also handles 'received-failure'. when 'disarmed', value status does not change)
+// checks whether 'received-success' had happened, and also handles 'received-failure'. when 'disarmed', value status does not change)
 // TODO: ...and a timeout? most of the time, these happen right after switch into the system task. but, since the sdk funcs don't block until success
 // (or at all, for anything), it might be nice to have some safeguards.
 

--- a/code/html/inline.mjs
+++ b/code/html/inline.mjs
@@ -70,7 +70,7 @@ export function needElement(elem, modules) {
  * @property {function(string, string, string): (Promise<string> | string)} [load]
  * process fs path from src=... or load(...) and return the 'code' to-be injected into the resulting element
  * @property {function(string): (void | Promise<void>)} [post]
- * execute some action when code was successfuly loaded into the dom
+ * execute some action when code was successfully loaded into the dom
  */
 
 /** 

--- a/code/html/spec/settings.spec.mjs
+++ b/code/html/spec/settings.spec.mjs
@@ -78,7 +78,7 @@ test('text input unchanged with empty value when original is missing', () => {
     expect(getDataForElement(node))
         .toEqual(getOriginalForElement(node));
 
-    const data = 'this never gets commited';
+    const data = 'this never gets committed';
     expect(getDataForElement(node)).toBe('');
     assert(!isChangedElement(node));
 

--- a/code/html/src/settings.mjs
+++ b/code/html/src/settings.mjs
@@ -47,7 +47,7 @@ import {
 // - User input. Same functions are triggered, but with an additional event for the container element that causes most recent element to be marked as changed.
 // Removal only happens from user input by triggering 'settings-group-del' from the target element.
 //
-// TODO: distinguish 'current' state to avoid sending keys when adding and immediatly removing the latest node?
+// TODO: distinguish 'current' state to avoid sending keys when adding and immediately removing the latest node?
 // TODO: previous implementation relied on defaultValue and / or jquery $(...).val(), but this does not really work where 'line' only has <select>
 
 /**

--- a/code/ota.py
+++ b/code/ota.py
@@ -349,7 +349,7 @@ def parse_commandline_args():
 
 
 def discover_devices(args):
-    # Look for services and try to immediatly print the device when it is discovered
+    # Look for services and try to immediately print the device when it is discovered
     # (unless --sort <field> is specified, then we will wait until discovery finishes
     listener = Listener(print_when_discovered=not args.sort)
 

--- a/code/scripts/memanalyzer.py
+++ b/code/scripts/memanalyzer.py
@@ -135,7 +135,7 @@ def parse_commandline_args():
         description=DESCRIPTION, formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
     parser.add_argument(
-        "-e", "--environment", help="platformio envrionment to use", default=DEFAULT_ENV
+        "-e", "--environment", help="platformio environment to use", default=DEFAULT_ENV
     )
     parser.add_argument(
         "--toolchain-prefix",


### PR DESCRIPTION
## Summary
- fix typos in documentation and comments
- correct various misspellings across source files

## Testing
- `python3 pre-commit` *(fails: SyntaxError)*

------
https://chatgpt.com/codex/tasks/task_b_683d2b048490832c8f9808da409b7673